### PR TITLE
Restrict FSharp.Core

### DIFF
--- a/WoofWare.Incremental/WoofWare.Incremental.fsproj
+++ b/WoofWare.Incremental/WoofWare.Incremental.fsproj
@@ -108,6 +108,7 @@
     <PackageReference Include="WoofWare.BalancedReducer" Version="1.0.2"/>
     <PackageReference Include="WoofWare.TimingWheel" Version="0.6.1"/>
     <PackageReference Include="WoofWare.WeakHashTable" Version="1.1.1"/>
+    <PackageReference Update="FSharp.Core" Version="5.0.0"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There was no need at all for such a high version.