### PR TITLE
Expose the timing wheel's next firing

### DIFF
--- a/WoofWare.Incremental/Incremental.fs
+++ b/WoofWare.Incremental/Incremental.fs
@@ -68,6 +68,7 @@ type IClock =
     abstract Snapshot<'a> : Clock -> Node<'a> -> at : TimeNs -> before : 'a -> Result<Node<'a>, string>
     abstract WatchNow : Clock -> Node<TimeNs>
     abstract AlarmPrecision : Clock -> TimeNs.Span
+    abstract NextAlarmFiresAt : Clock -> TimeNs voption
     abstract StepFunction : Clock -> init : 'a -> (TimeNs * 'a) list -> Node<'a>
     abstract IncrementalStepFunction<'a> : Clock -> StepFunction<'a> Node -> 'a Node
 
@@ -234,6 +235,9 @@ type IncrementalImpl (state : State) =
 
             member _.AlarmPrecision clock =
                 TimingWheel.alarmPrecision clock.TimingWheel
+
+            member _.NextAlarmFiresAt clock =
+                TimingWheel.nextAlarmFiresAt clock.TimingWheel
 
             member _.StepFunction clock init steps =
                 StepFunction.create init steps

--- a/WoofWare.Incremental/Incremental.fsi
+++ b/WoofWare.Incremental/Incremental.fsi
@@ -43,6 +43,7 @@ type IClock =
     abstract Snapshot<'a> : Clock -> Node<'a> -> at : TimeNs -> before : 'a -> Result<Node<'a>, string>
     abstract WatchNow : Clock -> Node<TimeNs>
     abstract AlarmPrecision : Clock -> TimeNs.Span
+    abstract NextAlarmFiresAt : Clock -> TimeNs voption
     abstract StepFunction : Clock -> init : 'a -> (TimeNs * 'a) list -> Node<'a>
 
     abstract IncrementalStepFunction<'a> : Clock -> StepFunction<'a> Node -> 'a Node

--- a/WoofWare.Incremental/SurfaceBaseline.txt
+++ b/WoofWare.Incremental/SurfaceBaseline.txt
@@ -217,7 +217,7 @@ WoofWare.Incremental.ForAnalyzer+KindModule inherit obj
 WoofWare.Incremental.ForAnalyzer+KindModule.toString [static method]: WoofWare.Incremental.ForAnalyzer+Kind -> string
 WoofWare.Incremental.ForAnalyzer.directlyObserved [static method]: WoofWare.Incremental.State -> WoofWare.Incremental.NodeCrate list
 WoofWare.Incremental.ForAnalyzer.traverse [static method]: WoofWare.Incremental.NodeCrate list -> (WoofWare.Incremental.NodeId -> WoofWare.Incremental.ForAnalyzer+Kind -> WoofWare.Incremental.ForAnalyzer+Cutoff -> WoofWare.Incremental.NodeId System.Collections.Generic.IReadOnlyList -> WoofWare.Incremental.NodeId System.Collections.Generic.IReadOnlyList -> WoofWare.Incremental.DotUserInfo option -> int -> int -> int -> unit) -> unit
-WoofWare.Incremental.IClock - interface with 14 member(s)
+WoofWare.Incremental.IClock - interface with 15 member(s)
 WoofWare.Incremental.IClock.AdvanceClock [method]: WoofWare.Incremental.Clock -> System.Int64 -> unit
 WoofWare.Incremental.IClock.AdvanceClockBy [method]: WoofWare.Incremental.Clock -> System.Int64 -> unit
 WoofWare.Incremental.IClock.After [method]: WoofWare.Incremental.Clock -> System.Int64 -> WoofWare.Incremental.BeforeOrAfter WoofWare.Incremental.Node
@@ -229,6 +229,7 @@ WoofWare.Incremental.IClock.Create' [method]: WoofWare.TimingWheel.TimingWheelCo
 WoofWare.Incremental.IClock.DefaultTimingWheelConfig [property]: [read-only] WoofWare.TimingWheel.TimingWheelConfig
 WoofWare.Incremental.IClock.get_DefaultTimingWheelConfig [method]: unit -> WoofWare.TimingWheel.TimingWheelConfig
 WoofWare.Incremental.IClock.IncrementalStepFunction [method]: WoofWare.Incremental.Clock -> 'a WoofWare.Incremental.StepFunction WoofWare.Incremental.Node -> 'a WoofWare.Incremental.Node
+WoofWare.Incremental.IClock.NextAlarmFiresAt [method]: WoofWare.Incremental.Clock -> System.Int64 Microsoft.FSharp.Core.FSharpValueOption
 WoofWare.Incremental.IClock.Snapshot [method]: WoofWare.Incremental.Clock -> 'a WoofWare.Incremental.Node -> System.Int64 -> 'a -> Microsoft.FSharp.Core.FSharpResult<'a WoofWare.Incremental.Node, string>
 WoofWare.Incremental.IClock.StepFunction [method]: WoofWare.Incremental.Clock -> 'a -> (System.Int64 * 'a) list -> 'a WoofWare.Incremental.Node
 WoofWare.Incremental.IClock.WatchNow [method]: WoofWare.Incremental.Clock -> System.Int64 WoofWare.Incremental.Node

--- a/WoofWare.Incremental/WoofWare.Incremental.fsproj
+++ b/WoofWare.Incremental/WoofWare.Incremental.fsproj
@@ -108,7 +108,7 @@
   <ItemGroup>
     <PackageReference Include="TypeEquality" Version="0.4.2"/>
     <PackageReference Include="WoofWare.BalancedReducer" Version="1.0.5" />
-    <PackageReference Include="WoofWare.TimingWheel" Version="0.6.4" />
+    <PackageReference Include="WoofWare.TimingWheel" Version="0.7.1" />
     <PackageReference Include="WoofWare.WeakHashTable" Version="1.2.2" />
     <PackageReference Update="FSharp.Core" Version="5.0.0"/>
   </ItemGroup>

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -321,8 +321,8 @@
   },
   {
     "pname": "WoofWare.TimingWheel",
-    "version": "0.6.4",
-    "hash": "sha256-IOz5Vr35O46XZl+eOc9SwYsZE9IQBdeA1wmGVHvExFo="
+    "version": "0.7.1",
+    "hash": "sha256-2QDCVj9n1tGZSAWNf4YX8H7z8JlJzFBcmKiNsjs/mEI="
   },
   {
     "pname": "WoofWare.WeakHashTable",


### PR DESCRIPTION
This is to allow an async runtime, which is using real time, to pump the graph at the appropriate instant.