### PR TITLE
Switch to Lychee

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: Enable Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@b8276522d77f21bf19d3574e5bc99186a6c7aa6c
       - name: Run link checker
-        run: nix develop --command markdown-link-check README.md
+        run: nix develop --command lychee README.md
 
   nuget-pack:
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766471942,
-        "narHash": "sha256-Wv+xrUNXgtxAXAMZE3EDzzeRgN1MEw+PnKr8zDozeLU=",
+        "lastModified": 1775126147,
+        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cfc52a405c6e85462364651a8f11e28ae8065c91",
+        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
         DOTNET_EnableDiagnostics = "0";
         packages = [
           pkgs.alejandra
-          pkgs.nodePackages.markdown-link-check
+          pkgs.lychee
           pkgs.shellcheck
           pkgs.xmlstarlet
           pkgs.claude-code


### PR DESCRIPTION
markdown-link-check is no longer packaged in nixpkgs.