### PR TITLE
Fix copy-paste bug in InternalObserver NextInObserving invariant

### DIFF
--- a/WoofWare.Incremental.Test/TestObserver.fs
+++ b/WoofWare.Incremental.Test/TestObserver.fs
@@ -770,3 +770,52 @@ module TestObserver =
         fix.Stabilize ()
         fix.Stabilize ()
         Observer.disallowFutureUse o
+
+    /// Build an observer left in [state] (i.e. Created/Unlinked, so not registered on its node) whose
+    /// [NextInObserving] dangles to a second observer. The back-link is kept consistent so that the *only*
+    /// invariant that can fire is "a Created/Unlinked observer must have no NextInObserving" -- exactly the
+    /// dangling-pointer corruption a buggy unlinkFromObserving would leave behind.
+    let private observerWithDanglingNextInObserving (state : InternalObserverState) : unit -> unit =
+        let fix = IncrementalFixture.Make ()
+        let I = fix.I
+        let node = I.Const 0
+        // Stabilize against a real observer so [node] is a fully consistent node and Node.invariant is happy.
+        let warm = I.Observe node
+        fix.Stabilize ()
+        ignore<Observer<int>> warm
+
+        let t = (State.createObserver (Some false) node).Value
+        let next = (State.createObserver (Some false) node).Value
+        t.NextInObserving <- ValueSome next
+        next.PrevInObserving <- ValueSome t
+        t.State <- state
+
+        fun () -> InternalObserver.invariant ignore t
+
+    [<Test>]
+    let ``created observer with dangling NextInObserving violates the invariant`` () =
+        expect {
+            snapshotThrows @"System.Exception: invariant failed"
+            return! observerWithDanglingNextInObserving InternalObserverState.Created
+        }
+
+    [<Test>]
+    let ``unlinked observer with dangling NextInObserving violates the invariant`` () =
+        expect {
+            snapshotThrows @"System.Exception: invariant failed"
+            return! observerWithDanglingNextInObserving InternalObserverState.Unlinked
+        }
+
+    [<Test>]
+    let ``freshly created observer with no observing links satisfies the invariant`` () =
+        // Positive control: confirms the node setup above is otherwise invariant-clean, so the failing
+        // tests fail because of the dangling link and nothing else.
+        let fix = IncrementalFixture.Make ()
+        let I = fix.I
+        let node = I.Const 0
+        let warm = I.Observe node
+        fix.Stabilize ()
+        ignore<Observer<int>> warm
+
+        let t = (State.createObserver (Some false) node).Value
+        InternalObserver.invariant ignore t

--- a/WoofWare.Incremental/InternalObserverInvariant.fs
+++ b/WoofWare.Incremental/InternalObserverInvariant.fs
@@ -66,7 +66,7 @@ module internal InternalObserverInvariant =
                 match t.State with
                 | InternalObserverState.Created
                 | InternalObserverState.Unlinked ->
-                    if t.PrevInObserving.IsSome then
+                    if t.NextInObserving.IsSome then
                         failwith "invariant failed"
                 | _ -> ()
 


### PR DESCRIPTION
## Problem

`InternalObserverInvariant.fs:69` — the `NextInObserving` block of `InternalObserver.invariant` re-tested `t.PrevInObserving.IsSome` (copy-pasted from the `PrevInObserving` block immediately above) instead of `t.NextInObserving.IsSome`.

The OCaml reference (`internal_observer.ml:104-114`) asserts `next_in_observing` is `none` for `Created`/`Unlinked` observers. As written, an observer in those states with a dangling `NextInObserving` — exactly the corruption a buggy `unlinkFromObserving` would leave behind — passed the invariant silently. This weakens the very machinery meant to catch such regressions elsewhere.

The companion `PrevInObserving` block (lines 51-63) was already correct; only the `NextInObserving` state check was wrong. The back-link consistency check in the same block (lines 73-77) was unaffected.

## Fix

One-character logic fix: `t.PrevInObserving.IsSome` → `t.NextInObserving.IsSome`.

## Tests (written first)

Added three direct tests of `InternalObserver.invariant` in `TestObserver.fs`:

- Two regression tests construct a `Created`/`Unlinked` observer whose `NextInObserving` dangles to a second observer, with the back-link kept *consistent* so that the **only** invariant that can fire is the state check under test. These were confirmed failing (`<no exception raised>`) against the buggy code and pass after the fix.
- A positive control (`Created` observer with no observing links) confirms the test's node setup is otherwise invariant-clean, so the regression tests fail for the right reason.

Full suite: 266 passed, 7 skipped (the usual GC/surface-doc conditionals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)